### PR TITLE
Lu/keychainmanager

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,4 +3,5 @@ source 'https://github.com/CocoaPods/Specs.git'
 target "ThreadGroup" do
 pod 'Reachability'
 pod 'libMeshCop', :git => 'git@github.com:IntrepidPursuits/iotivity-private.git', :branch => 'intrepid-ios-build'
+pod 'UICKeyChainStore', '~> 2.0'
 end

--- a/ThreadGroup.xcodeproj/project.pbxproj
+++ b/ThreadGroup.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		D917C4D91B558CF5000A5BE2 /* TGNetworkNameViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D917C4D71B558CF5000A5BE2 /* TGNetworkNameViewController.m */; };
 		D917C4DA1B558CF5000A5BE2 /* TGNetworkNameViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = D917C4D81B558CF5000A5BE2 /* TGNetworkNameViewController.xib */; };
 		D937177A1B617BDC00BE55DD /* TGPopup.m in Sources */ = {isa = PBXBuildFile; fileRef = D93717791B617BDC00BE55DD /* TGPopup.m */; };
+		D937177D1B62831200BE55DD /* TGKeychainManager.m in Sources */ = {isa = PBXBuildFile; fileRef = D937177C1B62831200BE55DD /* TGKeychainManager.m */; };
 		D93C816C1B2F663000A86EE1 /* TGHomeScreenViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D93C816A1B2F663000A86EE1 /* TGHomeScreenViewController.m */; };
 		D93C816D1B2F663000A86EE1 /* TGHomeScreenViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = D93C816B1B2F663000A86EE1 /* TGHomeScreenViewController.xib */; };
 		D95BC6851B43246E00271ED7 /* TGPopupContentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D95BC6831B43246E00271ED7 /* TGPopupContentViewController.m */; };
@@ -184,6 +185,8 @@
 		D917C4D81B558CF5000A5BE2 /* TGNetworkNameViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TGNetworkNameViewController.xib; sourceTree = "<group>"; };
 		D93717781B617BDC00BE55DD /* TGPopup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TGPopup.h; sourceTree = "<group>"; };
 		D93717791B617BDC00BE55DD /* TGPopup.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TGPopup.m; sourceTree = "<group>"; };
+		D937177B1B62831200BE55DD /* TGKeychainManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TGKeychainManager.h; sourceTree = "<group>"; };
+		D937177C1B62831200BE55DD /* TGKeychainManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TGKeychainManager.m; sourceTree = "<group>"; };
 		D93C81691B2F663000A86EE1 /* TGHomeScreenViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TGHomeScreenViewController.h; sourceTree = "<group>"; };
 		D93C816A1B2F663000A86EE1 /* TGHomeScreenViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TGHomeScreenViewController.m; sourceTree = "<group>"; };
 		D93C816B1B2F663000A86EE1 /* TGHomeScreenViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TGHomeScreenViewController.xib; sourceTree = "<group>"; };
@@ -490,6 +493,8 @@
 				CD86393E1B4330140044B2BE /* TGMeshcopManager.mm */,
 				CDFFFF061B5E9EA10011EA4B /* TGRouterServiceBrowser.h */,
 				CDFFFF071B5E9EA10011EA4B /* TGRouterServiceBrowser.m */,
+				D937177B1B62831200BE55DD /* TGKeychainManager.h */,
+				D937177C1B62831200BE55DD /* TGKeychainManager.m */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -781,6 +786,7 @@
 				CDFFFF051B5E8AEA0011EA4B /* TGRouter.m in Sources */,
 				D9E65C031B31AED800A184AB /* UIImage+ThreadGroup.m in Sources */,
 				CD8C68241B2730050091B548 /* UIFont+ThreadGroup.m in Sources */,
+				D937177D1B62831200BE55DD /* TGKeychainManager.m in Sources */,
 				0946F4061B500DF300EDB5DE /* TGSelectableCell.m in Sources */,
 				D9B456711B3C932400832112 /* TGAddProductViewController.m in Sources */,
 				CDFFFF081B5E9EA10011EA4B /* TGRouterServiceBrowser.m in Sources */,

--- a/ThreadGroup/Managers/TGKeychainManager.h
+++ b/ThreadGroup/Managers/TGKeychainManager.h
@@ -7,12 +7,13 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "TGRouter.h"
+
+@class TGRouter;
 
 @interface TGKeychainManager : NSObject
 
 + (instancetype)sharedManager;
-- (void)saveRouterItem:(TGRouter *)router;
-- (TGRouter *)getRouterItem;
+- (void)saveRouterItem:(TGRouter *)router withCompletion:(void(^)(NSError *error))completion;
+- (void)getRouterItemWithCompletion:(void(^)(TGRouter *router, NSError *error))completion;
 
 @end

--- a/ThreadGroup/Managers/TGKeychainManager.h
+++ b/ThreadGroup/Managers/TGKeychainManager.h
@@ -1,0 +1,18 @@
+//
+//  TGKeychainManager.h
+//  ThreadGroup
+//
+//  Created by LuQuan Intrepid on 7/24/15.
+//  Copyright (c) 2015 Intrepid Pursuits. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "TGRouter.h"
+
+@interface TGKeychainManager : NSObject
+
++ (instancetype)sharedManager;
+- (void)saveRouterItem:(TGRouter *)router;
+- (TGRouter *)getRouterItem;
+
+@end

--- a/ThreadGroup/Managers/TGKeychainManager.h
+++ b/ThreadGroup/Managers/TGKeychainManager.h
@@ -14,6 +14,6 @@
 
 + (instancetype)sharedManager;
 - (void)saveRouterItem:(TGRouter *)router withCompletion:(void(^)(NSError *error))completion;
-- (void)getRouterItemWithCompletion:(void(^)(TGRouter *router, NSError *error))completion;
+- (TGRouter *)getRouterItem;
 
 @end

--- a/ThreadGroup/Managers/TGKeychainManager.m
+++ b/ThreadGroup/Managers/TGKeychainManager.m
@@ -1,0 +1,32 @@
+//
+//  TGKeychainManager.m
+//  ThreadGroup
+//
+//  Created by LuQuan Intrepid on 7/24/15.
+//  Copyright (c) 2015 Intrepid Pursuits. All rights reserved.
+//
+
+#import "TGKeychainManager.h"
+
+static NSString * const kTGKeychainStoreIdentifier = @"io.intrepid.thread-group-ios";
+
+@implementation TGKeychainManager
+
++ (instancetype)sharedManager {
+    static TGKeychainManager *shared = nil;
+    static dispatch_once_t singleToken;
+    dispatch_once(&singleToken, ^{
+        shared = [[self alloc] init];
+    });
+    return shared;
+}
+
+- (void)saveRouterItem:(TGRouter *)router {
+
+}
+
+- (TGRouter *)getRouterItem {
+    return [TGRouter new];
+}
+
+@end

--- a/ThreadGroup/Managers/TGKeychainManager.m
+++ b/ThreadGroup/Managers/TGKeychainManager.m
@@ -6,9 +6,18 @@
 //  Copyright (c) 2015 Intrepid Pursuits. All rights reserved.
 //
 
+#import <UICKeychainStore/UICKeyChainStore.h>
 #import "TGKeychainManager.h"
+#import "TGRouter.h"
 
 static NSString * const kTGKeychainStoreIdentifier = @"io.intrepid.thread-group-ios";
+static NSString * const KTGRouterObjectKey = @"kTGRouterObjectKey";
+
+@interface TGKeychainManager()
+@property (strong, nonatomic) UICKeyChainStore *keychain;
+@property (strong, nonatomic) NSKeyedArchiver *archiver;
+@property (strong, nonatomic) NSKeyedUnarchiver *unArchiver;
+@end
 
 @implementation TGKeychainManager
 
@@ -21,12 +30,41 @@ static NSString * const kTGKeychainStoreIdentifier = @"io.intrepid.thread-group-
     return shared;
 }
 
-- (void)saveRouterItem:(TGRouter *)router {
-
+- (void)saveRouterItem:(TGRouter *)router withCompletion:(void(^)(NSError *error))completion {
+    NSData *objectData = [self encodeRouterItem:router];
+    NSError *saveError;
+    [self.keychain setData:objectData forKey:KTGRouterObjectKey error:&saveError];
+    if (completion) {
+        completion(saveError);
+    }
 }
 
-- (TGRouter *)getRouterItem {
-    return [TGRouter new];
+- (void)getRouterItemWithCompletion:(void(^)(TGRouter *router, NSError *error))completion {
+    NSError *getError;
+    NSData *data = [self.keychain dataForKey:KTGRouterObjectKey error:&getError];
+    TGRouter *router = [self decodeRouterItem:data];
+    if (completion) {
+        completion(router, getError);
+    }
+}
+
+#pragma mark - Encode/Decode TGRouter
+
+- (NSData *)encodeRouterItem:(TGRouter *)router {
+    return [NSKeyedArchiver archivedDataWithRootObject:router];
+}
+
+- (TGRouter *)decodeRouterItem:(NSData *)data {
+    return [NSKeyedUnarchiver unarchiveObjectWithData:data];
+}
+
+#pragma mark - UICKeychainStore
+
+- (UICKeyChainStore *)keychain {
+    if (!_keychain) {
+        _keychain = [[UICKeyChainStore alloc] initWithService:kTGKeychainStoreIdentifier];
+    }
+    return _keychain;
 }
 
 @end

--- a/ThreadGroup/Managers/TGKeychainManager.m
+++ b/ThreadGroup/Managers/TGKeychainManager.m
@@ -39,12 +39,13 @@ static NSString * const KTGRouterObjectKey = @"kTGRouterObjectKey";
     }
 }
 
-- (void)getRouterItemWithCompletion:(void(^)(TGRouter *router, NSError *error))completion {
+- (TGRouter *)getRouterItem {
     NSError *getError;
     NSData *data = [self.keychain dataForKey:KTGRouterObjectKey error:&getError];
-    TGRouter *router = [self decodeRouterItem:data];
-    if (completion) {
-        completion(router, getError);
+    if (getError) {
+        return nil;
+    } else {
+        return [self decodeRouterItem:data];
     }
 }
 

--- a/ThreadGroup/Models/TGRouter.h
+++ b/ThreadGroup/Models/TGRouter.h
@@ -16,5 +16,6 @@
 @property (nonatomic, readonly) NSInteger port;
 
 - (instancetype)initWithService:(NSNetService *)service;
+- (instancetype)initWithCoder:(NSCoder *)aDecoder;
 
 @end

--- a/ThreadGroup/Models/TGRouter.m
+++ b/ThreadGroup/Models/TGRouter.m
@@ -15,6 +15,13 @@ typedef union {
     struct sockaddr_in6 ipv6;
 } ip_socket_address;
 
+@interface TGRouter() <NSSecureCoding>
+@property (nonatomic, strong) NSString *name;
+@property (nonatomic, strong) NSString *networkName;
+@property (nonatomic, strong) NSString *ipAddress;
+@property (nonatomic) NSInteger port;
+@end
+
 @implementation TGRouter
 
 - (instancetype)initWithService:(NSNetService *)service {
@@ -55,6 +62,30 @@ typedef union {
     }
     
     return nil;
+}
+
+#pragma mark - NSSecureCodiing
+
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    self = [super init];
+    if (self) {
+        self.name = [aDecoder decodeObjectForKey:@"name"];
+        self.networkName = [aDecoder decodeObjectForKey:@"networkName"];
+        self.ipAddress = [aDecoder decodeObjectForKey:@"ipAddress"];
+        self.port = [aDecoder decodeIntegerForKey:@"port"];
+    }
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    [aCoder encodeObject:self.name forKey:@"name"];
+    [aCoder encodeObject:self.networkName forKey:@"networkName"];
+    [aCoder encodeObject:self.ipAddress forKey:@"ipAddress"];
+    [aCoder encodeInteger:self.port forKey:@"port"];
 }
 
 #pragma mark - Overridden


### PR DESCRIPTION
Note:
- The `TGRouter` object is encoded into NSData to be stored in the keychain.
