### PR TITLE
TGSettingsManager slimming/refactor

### DIFF
--- a/ThreadGroup/Controllers/TGMainViewController.m
+++ b/ThreadGroup/Controllers/TGMainViewController.m
@@ -176,7 +176,7 @@ static CGFloat const kTGScannerViewAnimationDuration = 0.8f;
 
 - (void)configureMainViewForViewState:(TGMainViewState)viewState {
     BOOL isScanning = (viewState == TGMainViewStateConnectDevicePassphrase || viewState == TGMainViewStateConnectDeviceScanning);
-    if (isScanning && [[TGSettingsManager sharedManager] hasSeenScannerTutorial] == NO) {
+    if (isScanning && [TGSettingsManager hasSeenScannerTutorial] == NO) {
         viewState = TGMainViewStateConnectDeviceTutorial;
         [self setPopupNotificationForState:viewState animated:NO];
     }
@@ -546,7 +546,7 @@ static CGFloat const kTGScannerViewAnimationDuration = 0.8f;
 - (void)parentPopup:(TGPopupParentView *)popupParent didReceiveTouchForChildPopupAtIndex:(NSInteger)index {
     UIView *selectedView = [self.popupView popupAtIndex:index];
     if (selectedView == self.tutorialPopup) {
-        [[TGSettingsManager sharedManager] setHasSeenScannerTutorial:YES];
+        [TGSettingsManager setHasSeenScannerTutorial:YES];
         [self setViewState:TGMainViewStateConnectDeviceScanning];
         [self setPopupNotificationForState:self.viewState animated:YES];
     } else if (selectedView == self.addDevicePopup) {

--- a/ThreadGroup/Managers/TGSettingsManager.h
+++ b/ThreadGroup/Managers/TGSettingsManager.h
@@ -10,12 +10,10 @@
 
 @interface TGSettingsManager : NSObject
 
-+ (instancetype)sharedManager;
++ (BOOL)debugModeEnabled;
++ (void)setDebugModeEnabled:(BOOL)enabled;
 
-- (BOOL)debugModeEnabled;
-- (void)setDebugModeEnabled:(BOOL)enabled;
-
-- (BOOL)hasSeenScannerTutorial;
-- (void)setHasSeenScannerTutorial:(BOOL)hasSeen;
++ (BOOL)hasSeenScannerTutorial;
++ (void)setHasSeenScannerTutorial:(BOOL)hasSeen;
 
 @end

--- a/ThreadGroup/Managers/TGSettingsManager.m
+++ b/ThreadGroup/Managers/TGSettingsManager.m
@@ -13,31 +13,22 @@ static NSString * const TGSettingsManagerHasSeenScannerTutorial = @"TGSettingsMa
 
 @implementation TGSettingsManager
 
-+ (instancetype)sharedManager {
-    static id _sharedInstance = nil;
-    static dispatch_once_t oncePredicate;
-    dispatch_once(&oncePredicate, ^{
-        _sharedInstance = [[self alloc] init];
-    });
-    return _sharedInstance;
-}
-
 #pragma mark - Public Settings
 
-- (BOOL)debugModeEnabled {
++ (BOOL)debugModeEnabled {
     return [[[NSUserDefaults standardUserDefaults] objectForKey:TGSettingsManagerDebugModeEnabled] boolValue];
 }
 
-- (void)setDebugModeEnabled:(BOOL)enabled {
++ (void)setDebugModeEnabled:(BOOL)enabled {
     [[NSUserDefaults standardUserDefaults] setObject:@(enabled) forKey:TGSettingsManagerDebugModeEnabled];
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
-- (BOOL)hasSeenScannerTutorial {
++ (BOOL)hasSeenScannerTutorial {
     return [[[NSUserDefaults standardUserDefaults] objectForKey:TGSettingsManagerHasSeenScannerTutorial] boolValue];
 }
 
-- (void)setHasSeenScannerTutorial:(BOOL)hasSeen {
++ (void)setHasSeenScannerTutorial:(BOOL)hasSeen {
     [[NSUserDefaults standardUserDefaults] setObject:@(hasSeen) forKey:TGSettingsManagerHasSeenScannerTutorial];
     [[NSUserDefaults standardUserDefaults] synchronize];
 }


### PR DESCRIPTION
Changed TGSettingsManager to use class methods instead of static initializing a shared copy of itself. Saves on memory, and there's no reason for us to be initializing a copy that stays around forever.
